### PR TITLE
Speedup collect_lists and add test

### DIFF
--- a/ptls/make_datasets_spark.py
+++ b/ptls/make_datasets_spark.py
@@ -193,7 +193,7 @@ class DatasetConverter:
 
     def collect_lists(self, df, col_id):
         col_list = ['event_time'] + [col for col in df.columns if col != col_id and col != 'event_time']
-        unpack_col_list = [col_id] + [F.col(f'struct.{col}').alias(col) for col in col_list]
+        unpack_col_list = [col_id] + [F.col(f'_struct.{col}').alias(col) for col in col_list]
 
         if self.config.save_partitioned_data:
             df = df.withColumn('mon_id', (F.col('event_time') / 30).cast('int'))
@@ -201,9 +201,9 @@ class DatasetConverter:
             unpack_col_list.append('mon_id')
 
         # Put columns into structs and collect structs.
-        df = df.groupBy(col_id).agg(F.sort_array(F.collect_list(F.struct(*col_list))).alias('struct'))
+        df = df.groupBy(col_id).agg(F.sort_array(F.collect_list(F.struct(*col_list))).alias('_struct'))
         # Unpack structs.
-        df = df.select(*unpack_col_list).drop('struct').persist()
+        df = df.select(*unpack_col_list).drop('_struct').persist()
         # Get counts.
         df = df.withColumn('trx_count', F.size(F.col('event_time')).cast('long'))
         return df

--- a/ptls/preprocessing/pyspark/user_group_transformer.py
+++ b/ptls/preprocessing/pyspark/user_group_transformer.py
@@ -59,7 +59,7 @@ class UserGroupTransformer(ColTransformerPandasMixin, ColTransformer):
             df = df.withColumn('_struct', array_slice)
 
         # Unpack structs.
-        df = df.select(*unpack_col_list).drop('_struct').persist()
+        df = df.select(*unpack_col_list)
 
         # Select last elements.
         for col in self.cols_last_item:

--- a/ptls/preprocessing/pyspark/user_group_transformer.py
+++ b/ptls/preprocessing/pyspark/user_group_transformer.py
@@ -59,7 +59,7 @@ class UserGroupTransformer(ColTransformerPandasMixin, ColTransformer):
             df = df.withColumn('_struct', array_slice)
 
         # Unpack structs.
-        df = df.select(*unpack_col_list).drop('struct').persist()
+        df = df.select(*unpack_col_list).drop('_struct').persist()
 
         # Select last elements.
         for col in self.cols_last_item:

--- a/ptls/preprocessing/pyspark/user_group_transformer.py
+++ b/ptls/preprocessing/pyspark/user_group_transformer.py
@@ -46,28 +46,23 @@ class UserGroupTransformer(ColTransformerPandasMixin, ColTransformer):
                                  f'Found {x.columns}')
         return self
 
-
     def transform(self, x: pyspark.sql.DataFrame):
-        col_list = [col for col in x.columns if col != self.col_name_original]
+        col_list = ['event_time'] + [col for col in x.columns if col != self.col_name_original and col != 'event_time']
+        unpack_col_list = [self.col_name_original] + [F.col(f'_struct.{col}').alias(col) for col in col_list]
 
-        df = x.withColumn('_rn', F.row_number().over(
-            Window.partitionBy(self.col_name_original).orderBy(F.col('event_time').desc())))
+        # Put columns into structs and collect structs.
+        df = x.groupBy(self.col_name_original).agg(F.sort_array(F.collect_list(F.struct(*col_list))).alias('_struct'))
         if self.max_trx_count is not None:
-            df = df.where(F.col('_rn') <= self.max_trx_count)
+            array_slice = F.slice(F.col('_struct'),
+                                  F.greatest(F.size(F.col('_struct')) - (self.max_trx_count - 1), F.lit(1)),
+                                  self.max_trx_count)
+            df = df.withColumn('_struct', array_slice)
 
-        df = df.groupby(self.col_name_original).agg(
-            *[
-                F.sort_array(F.collect_list(F.struct('_rn', col)), asc=False).alias(col)
-                for col in col_list if col not in self.cols_last_item
-            ],
-            *[
-                F.struct(F.max(F.when(F.col('_rn') == 1, F.col(col))).alias(col)).alias(col)
-                for col in col_list if col in self.cols_last_item
-            ],
-        )
-        for col in col_list:
-            df = df.withColumn(col, F.col(f'{col}.{col}'))
+        # Unpack structs.
+        df = df.select(*unpack_col_list).drop('struct').persist()
 
-        # we don't heed to drop original column in this transformer
-        # x = super().transform(x)
+        # Select last elements.
+        for col in self.cols_last_item:
+            df = df.withColumn(col, F.element_at(F.col(col), -1))
+
         return df

--- a/ptls_tests/test_make_datasets_spark.py
+++ b/ptls_tests/test_make_datasets_spark.py
@@ -86,7 +86,8 @@ class TestCollectLists(TestCase):
             converter_v1.config = config
             df_lists = converter.collect_lists(df, 'client_id')
             df_lists_v1 = converter_v1.collect_lists(df, 'client_id')
-            self.assertEqualDataframes(df_lists, df_lists_v1, 'client_id', ignore_nullable=True)
+            sort_col = ['client_id', 'mon_id'] if save_partitioned_data else 'client_id'
+            self.assertEqualDataframes(df_lists, df_lists_v1, sort_col, ignore_nullable=True)
 
 
 if __name__ == "__main__":

--- a/ptls_tests/test_make_datasets_spark.py
+++ b/ptls_tests/test_make_datasets_spark.py
@@ -62,6 +62,7 @@ def cmp_schema(s1, s2, ignore_nullable=False):
 class TestCollectLists(TestCase):
     def setUp(self):
         self.spark = SparkSession.builder.master("local").appName("test").getOrCreate()
+        self.maxDiff = None
 
     def assertEqualDataframes(self, df1, df2, sort_col, ignore_nullable=False):
         cmp_schema(df1.schema, df2.schema, ignore_nullable=ignore_nullable)
@@ -87,4 +88,8 @@ class TestCollectLists(TestCase):
 
 
 if __name__ == "__main__":
+    if 'unittest.util' in __import__('sys').modules:
+        # Show full diff in self.assertEqual.
+        __import__('sys').modules['unittest.util']._MAX_LENGTH = 999999999
+
     main()

--- a/ptls_tests/test_make_datasets_spark.py
+++ b/ptls_tests/test_make_datasets_spark.py
@@ -1,0 +1,90 @@
+import time
+import pyspark
+import pyspark.sql.functions as F
+from argparse import Namespace
+from unittest import TestCase, main
+from pathlib import Path
+from pyspark.sql import SparkSession, Window
+from pyspark.sql.types import ArrayType, StructType, StructField
+
+from ptls.make_datasets_spark import DatasetConverter
+
+
+class DatasetConverterV1(DatasetConverter):
+    """Old collect_lists implementation."""
+    def collect_lists(self, df, col_id):
+        col_list = [col for col in df.columns if col != col_id]
+
+        if self.config.save_partitioned_data:
+            df = df.withColumn('mon_id', (F.col('event_time') / 30).cast('int'))
+            col_id = [col_id, 'mon_id']
+
+        df = df \
+            .withColumn('trx_count', F.count(F.lit(1)).over(Window.partitionBy(col_id))) \
+            .withColumn('_rn', F.row_number().over(Window.partitionBy(col_id).orderBy('event_time')))
+
+        for col in col_list:
+            df = df.withColumn(col, F.collect_list(col).over(Window.partitionBy(col_id).orderBy('_rn'))) \
+
+        df = df.filter('_rn = trx_count').drop('_rn')
+        return df
+
+
+def cmp_schema(s1, s2, ignore_nullable=False):
+    if isinstance(s1, StructType):
+        assert isinstance(s2, StructType)
+        if len(s1) != len(s2):
+            raise AssertionError('The number of columns mismatch')
+        s1 = sorted(s1, key=lambda f: f.name)
+        s2 = sorted(s2, key=lambda f: f.name)
+        for f1, f2 in zip(s1, s2):
+            cmp_schema(f1, f2, ignore_nullable=ignore_nullable)
+    elif isinstance(s1, StructField):
+        if not isinstance(s2, StructField):
+            raise AssertionError(f'Different types: {s1} != {s2}.')
+        cmp_schema(s1.dataType, s2.dataType, ignore_nullable=ignore_nullable)
+        attrs = ['name', 'metadata']
+        if not ignore_nullable:
+            attrs.append('nullable')
+        for attr in attrs:
+            if getattr(s1, attr) != getattr(s2, attr):
+                raise AssertionError(f'Struct fields differ: {s1} != {s2}.')
+    elif isinstance(s1, ArrayType):
+        if not isinstance(s2, ArrayType):
+            raise AssertionError(f'Different types: {s1} != {s2}.')
+        cmp_schema(s1.elementType, s2.elementType, ignore_nullable=ignore_nullable)
+        if (not ignore_nullable) and (s1 != s2):
+            raise AssertionError(f'Arrays differ: {s1} != {s2}.')
+    elif s1 != s2:
+        raise AssertionError(f'Elements differ: {s1} != {s2}.')
+
+
+class TestCollectLists(TestCase):
+    def setUp(self):
+        self.spark = SparkSession.builder.master("local").appName("test").getOrCreate()
+
+    def assertEqualDataframes(self, df1, df2, sort_col, ignore_nullable=False):
+        cmp_schema(df1.schema, df2.schema, ignore_nullable=ignore_nullable)
+        rows1 = list(map(lambda row: row.asDict(), df1.orderBy(sort_col).collect()))
+        rows2 = list(map(lambda row: row.asDict(), df2.orderBy(sort_col).collect()))
+        self.assertEqual(rows1, rows2)
+
+    def test_compare_v1(self):
+        loader = self.spark.read.format("csv").option("header","true").option("inferSchema","true")
+        df = loader.load(str(Path(__file__).parent / "age-transactions.csv"))
+        expression = (F.col('trans_date') + F.rand()) * 10000
+        df = df.withColumn('event_time', expression).drop('trans_date')
+        start = time.time()
+        converter = DatasetConverter()
+        converter_v1 = DatasetConverterV1()
+        for save_partitioned_data in [False, True]:
+            config = Namespace(save_partitioned_data=save_partitioned_data)
+            converter.config = config
+            converter_v1.config = config
+            df_lists = converter.collect_lists(df, 'client_id')
+            df_lists_v1 = converter_v1.collect_lists(df, 'client_id')
+            self.assertEqualDataframes(df_lists, df_lists_v1, 'client_id', ignore_nullable=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/ptls_tests/test_make_datasets_spark.py
+++ b/ptls_tests/test_make_datasets_spark.py
@@ -68,7 +68,9 @@ class TestCollectLists(TestCase):
         cmp_schema(df1.schema, df2.schema, ignore_nullable=ignore_nullable)
         rows1 = list(map(lambda row: row.asDict(), df1.orderBy(sort_col).collect()))
         rows2 = list(map(lambda row: row.asDict(), df2.orderBy(sort_col).collect()))
-        self.assertEqual(rows1, rows2)
+        self.assertEqual(len(rows1), len(rows2))
+        for row1, row2 in zip(rows1, rows2):
+            self.assertEqual(row1, row2)
 
     def test_compare_v1(self):
         loader = self.spark.read.format("csv").option("header","true").option("inferSchema","true")


### PR DESCRIPTION
Speedup Spark data preparation:
1. Reduce amount of sorts during collect lists
2. Don't attach collected lists to each row.

Speedup on bowl2019: 5:13 -> 2:14
Speedup on AlphaBattle: 37:07 -> 23:45