### PR TITLE
drop useless args from super()

### DIFF
--- a/ptls/frames/coles/losses/binomial_deviance_loss.py
+++ b/ptls/frames/coles/losses/binomial_deviance_loss.py
@@ -12,7 +12,7 @@ class BinomialDevianceLoss(nn.Module):
     """
 
     def __init__(self, pair_selector, alpha=1, beta=1, C=1):
-        super(BinomialDevianceLoss, self).__init__()
+        super().__init__()
         self.alpha = alpha
         self.beta = beta
         self.C = C

--- a/ptls/frames/coles/losses/complex_loss.py
+++ b/ptls/frames/coles/losses/complex_loss.py
@@ -6,7 +6,7 @@ class ComplexLoss(torch.nn.Module):
 
     """
     def __init__(self, ml_loss, aug_loss, ml_loss_weight=1.):
-        super(ComplexLoss, self).__init__()
+        super().__init__()
         self.aug_loss = aug_loss
         self.ml_loss = ml_loss
         self.ml_loss_weight = ml_loss_weight

--- a/ptls/frames/coles/losses/contrastive_loss.py
+++ b/ptls/frames/coles/losses/contrastive_loss.py
@@ -14,7 +14,7 @@ class ContrastiveLoss(nn.Module):
     """
 
     def __init__(self, margin, sampling_strategy, distributed_mode = False, do_loss_mult = False):
-        super(ContrastiveLoss, self).__init__()
+        super().__init__()
         self.margin = margin
         self.pair_selector = sampling_strategy
         self.distributed_mode = distributed_mode

--- a/ptls/frames/coles/losses/histogram_loss.py
+++ b/ptls/frames/coles/losses/histogram_loss.py
@@ -14,7 +14,7 @@ class HistogramLoss(torch.nn.Module):
     """
 
     def __init__(self, num_steps=100):
-        super(HistogramLoss, self).__init__()
+        super().__init__()
         self.step = 2 / (num_steps - 1)
         self.eps = 1 / num_steps
         self.t = torch.arange(-1, 1+self.step, self.step).view(-1, 1)

--- a/ptls/frames/coles/losses/margin_loss.py
+++ b/ptls/frames/coles/losses/margin_loss.py
@@ -13,7 +13,7 @@ class MarginLoss(torch.nn.Module):
     """
 
     def __init__(self, pair_selector, margin=1, beta=1.2):
-        super(MarginLoss, self).__init__()
+        super().__init__()
         self.margin = margin
         self.beta = beta
         self.pair_selector = pair_selector

--- a/ptls/frames/coles/losses/triplet_loss.py
+++ b/ptls/frames/coles/losses/triplet_loss.py
@@ -11,7 +11,7 @@ class TripletLoss(nn.Module):
     """
 
     def __init__(self, margin, triplet_selector):
-        super(TripletLoss, self).__init__()
+        super().__init__()
         self.margin = margin
         self.triplet_selector = triplet_selector
 

--- a/ptls/frames/coles/losses/vicreg_loss.py
+++ b/ptls/frames/coles/losses/vicreg_loss.py
@@ -8,7 +8,7 @@ class VicregLoss(torch.nn.Module):
 
     """
     def __init__(self, sim_coeff, std_coeff, cov_coeff):
-        super(VicregLoss, self).__init__()
+        super().__init__()
 
         self.sim_coeff = sim_coeff
         self.std_coeff = std_coeff

--- a/ptls/frames/coles/sampling_strategies/all_positive_pair_selector.py
+++ b/ptls/frames/coles/sampling_strategies/all_positive_pair_selector.py
@@ -10,7 +10,7 @@ class AllPositivePairSelector(PairSelector):
     """
 
     def __init__(self, balance=True):
-        super(AllPositivePairSelector, self).__init__()
+        super().__init__()
         self.balance = balance
 
     def get_pairs(self, embeddings, labels):

--- a/ptls/frames/coles/sampling_strategies/all_triplets_selector.py
+++ b/ptls/frames/coles/sampling_strategies/all_triplets_selector.py
@@ -13,7 +13,7 @@ class AllTripletSelector(TripletSelector):
     """
 
     def __init__(self):
-        super(AllTripletSelector, self).__init__()
+        super().__init__()
 
     def get_triplets(self, embeddings, labels):
         np_labels = labels.cpu().data.numpy()

--- a/ptls/frames/coles/sampling_strategies/distance_weighted_pair_selector.py
+++ b/ptls/frames/coles/sampling_strategies/distance_weighted_pair_selector.py
@@ -35,7 +35,7 @@ class DistanceWeightedPairSelector(PairSelector):
     """
 
     def __init__(self, batch_k, cutoff=0.5, nonzero_loss_cutoff=1.4, normalize=False):
-        super(DistanceWeightedPairSelector, self).__init__()
+        super().__init__()
         self.batch_k = batch_k
         self.cutoff = cutoff
         self.nonzero_loss_cutoff = nonzero_loss_cutoff

--- a/ptls/frames/coles/sampling_strategies/hard_negative_pair_selector.py
+++ b/ptls/frames/coles/sampling_strategies/hard_negative_pair_selector.py
@@ -11,7 +11,7 @@ class HardNegativePairSelector(PairSelector):
     """
 
     def __init__(self, neg_count=1):
-        super(HardNegativePairSelector, self).__init__()
+        super().__init__()
         self.neg_count = neg_count
 
     def get_pairs(self, embeddings, labels):

--- a/ptls/frames/coles/sampling_strategies/hard_triplet_selector.py
+++ b/ptls/frames/coles/sampling_strategies/hard_triplet_selector.py
@@ -10,7 +10,7 @@ class HardTripletSelector(TripletSelector):
     """
 
     def __init__(self, neg_count=1):
-        super(HardTripletSelector, self).__init__()
+        super().__init__()
         self.neg_count = neg_count
 
     def get_triplets(self, embeddings, labels):

--- a/ptls/frames/coles/sampling_strategies/random_negative_triplet_selector.py
+++ b/ptls/frames/coles/sampling_strategies/random_negative_triplet_selector.py
@@ -9,7 +9,7 @@ class RandomNegativeTripletSelector(TripletSelector):
     """
 
     def __init__(self, neg_count=1):
-        super(RandomNegativeTripletSelector, self).__init__()
+        super().__init__()
         self.neg_count = neg_count
 
     def get_triplets(self, embeddings, labels):

--- a/ptls/frames/coles/sampling_strategies/semi_hard_triplet_selector.py
+++ b/ptls/frames/coles/sampling_strategies/semi_hard_triplet_selector.py
@@ -14,7 +14,7 @@ class SemiHardTripletSelector(TripletSelector):
     """
 
     def __init__(self, neg_count=1):
-        super(SemiHardTripletSelector, self).__init__()
+        super().__init__()
         self.neg_count = neg_count
 
     def get_triplets(self, embeddings, labels):

--- a/ptls/metric_learn/ml_models.py
+++ b/ptls/metric_learn/ml_models.py
@@ -21,7 +21,7 @@ def projection_head(input_size, output_size):
 
 class ModelEmbeddingEnsemble(nn.Module):
     def __init__(self, submodels):
-        super(ModelEmbeddingEnsemble, self).__init__()
+        super().__init__()
         self.models = nn.ModuleList(submodels)
 
     def forward(self, x: PaddedBatch, h_0: torch.Tensor = None):

--- a/ptls/nn/binarization.py
+++ b/ptls/nn/binarization.py
@@ -18,7 +18,7 @@ binary = Binarization.apply
 
 class BinarizationLayer(nn.Module):
     def __init__(self, hs_from, hs_to):
-        super(BinarizationLayer, self).__init__()
+        super().__init__()
         self.linear = nn.Linear(hs_from, hs_to, bias=False)
 
     def forward(self, x):

--- a/ptls/nn/seq_encoder/transformer_encoder.py
+++ b/ptls/nn/seq_encoder/transformer_encoder.py
@@ -16,7 +16,7 @@ class PositionalEncoding(nn.Module):
                  use_start_random_shift=True,
                  max_len=5000,
                  ):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.use_start_random_shift = use_start_random_shift
         self.max_len = max_len
 

--- a/ptls/nn/trx_encoder/float_positional_encoding.py
+++ b/ptls/nn/trx_encoder/float_positional_encoding.py
@@ -6,7 +6,7 @@ from torch import nn as nn
 
 class FloatPositionalEncoding(nn.Module):
     def __init__(self, out_size):
-        super(FloatPositionalEncoding, self).__init__()
+        super().__init__()
 
         self.out_size = out_size
 

--- a/ptls/swa.py
+++ b/ptls/swa.py
@@ -237,7 +237,7 @@ class SWA(Optimizer):
                           "param_groups": state_dict["param_groups"]}
         opt_state_dict = {"state": state_dict["opt_state"],
                           "param_groups": state_dict["param_groups"]}
-        super(SWA, self).load_state_dict(swa_state_dict)
+        super().load_state_dict(swa_state_dict)
         self.optimizer.load_state_dict(opt_state_dict)
         self.opt_state = self.optimizer.state
 


### PR DESCRIPTION
Removed unnecessary parameters in the super() function to avoid code divergence
unit tests passed as in main
