### PR TITLE
Fix typos in ./docs; Add docstrings and help properties of cmd line args in make_datasets_spark.py 

### DIFF
--- a/docs/data_load/datasets.md
+++ b/docs/data_load/datasets.md
@@ -115,7 +115,7 @@ They takes `i_filters` as list of `iterable_processing` objects.
 
 ### Augmentations
 
-Sometimes we have to change an items from train data. This is `augmentations`.
+Sometimes we have to change items from train data. This is what `augmentations` do.
 They are in `ptls.data_load.augmentations`.
 
 Example:
@@ -138,11 +138,11 @@ Here `RandomSlice` augmentation take a random slice from source record.
 | Place it be before persist stage to run it once and save total cpu resource | Don't place it before persist stage because it kills the random |
 | Can delete items | Can not delete items |
 | Can yield new items | Can not create new items |
-| Works a generator and requires iterable processing | Works as a function can be both map or iterable |
+| Works as a generator and requires iterable processing | Works as a function can be both map or iterable |
 
 ## In memory data
 
-In memory data is common case. Data can a list or generator with feature dicts.
+In memory data is common case. Data can be a list or generator with feature dicts.
 
 ```python
 import torch
@@ -184,7 +184,7 @@ def data_gen(n):
 
 Both datasets support any kind of input: list or generator.
 As all datasets supports tha same format (list or generator) as input and output they can be chained.
-This make sense for some cases.
+This makes sense for some cases.
 
 Data pipelines:
 
@@ -237,7 +237,7 @@ for batch in dl:
 
 ## Parquet file read
 
-For large amount of data `pyspark` is possible engine to prepare data and convert it in feature dict format.
+For large amount of data `pyspark` is a possible engine to prepare data and convert it in feature dict format.
 See `demo/pyspark-parquet.ipynb` with example of data preprocessing with `pyspark` and parquet file preparation.
 
 `ptls.data_load.datasets.ParquetDataset` is a dataset which reads parquet files with feature dicts.
@@ -249,8 +249,8 @@ See `demo/pyspark-parquet.ipynb` with example of data preprocessing with `pyspar
 - looks like a generator
 - supports `i_filters`
 
-You can feed `ParquetDataset` directly fo dataloader for `iterable` way of usage.
-Cou can combine `ParquetDataset` with `MemoryMapDataset` to `map` way of usage.
+You can feed `ParquetDataset` directly to dataloader for `iterable` way of usage.
+You can combine `ParquetDataset` with `MemoryMapDataset` to `map` way of usage.
 
 `ParquetDataset` requires parquet file names. Usually `spark` saves many parquet files for one dataset, 
 depending on the number of partitions.
@@ -264,7 +264,7 @@ Many files for one dataset allows you to:
 
 `ptls.data_load.datasets.PersistDataset` store items from source dataset to the memory.
 
-If you source data is iterator (like python generator or `ParquetDataset`) 
+If your source data is iterator (like python generator or `ParquetDataset`) 
 all `i_filters` will be called each time when you access the data.
 Persist the data into memory and `i_filters` will be called once.
 Much memory may be used to store all dataset items.

--- a/docs/data_load/date_pipeline.md
+++ b/docs/data_load/date_pipeline.md
@@ -1,6 +1,6 @@
 # Data pipeline
 
-All process support `map` and `iterable` data.
+All processes support `map` and `iterable` data.
 
 There are steps in pipeline:
 

--- a/docs/feature_naming.md
+++ b/docs/feature_naming.md
@@ -2,19 +2,19 @@
 
 ## Feature types
 
-Information about transaction features are stored as array in dictionary.
+Information about transaction features is stored as arrays in a dictionary.
 
-There are feature types:
+There are the feature types:
 
-- Sequential feature - is a `np.ndarray` or `torch.tensor` of shape `(seq_len,)`
+- Sequential feature - is a `np.ndarray` or a `torch.tensor` of shape `(seq_len,)`
     - for categorical features contains category indexes with type `long`
     - for numerical features contains feature value with type `float`
 - Scalar values. It can be `target`, `id`, `labels` or `scalar features`.
-Types are depends on purpose. Type should be compatible with torch if value will be fed into neural network
+Types depend on purpose. Type should be compatible with torch if value will be fed into a neural network
 - Array values. It also can be `target`, `id`, `labels` or `vector features`.
 Type is `np.ndarray` or `torch.tensor`.
 
-Sequential features correspond user's transactions.
+Sequential features correspond to a user's transactions.
 The length of each user's sequential feature is equal to the length of the entire sequence.
 The order of each user's sequential feature is the same as sequence order.
 Sequential feature length `seq_len` may vary from user to user.
@@ -24,18 +24,18 @@ Array features have a constant shape. This shape is the same for all users.
 This why we use `pad_sequence` which align length for sequential features and `stack` for array features
 during batch collection.
 
-`ptls` extract only sequential features for unsupervised task and additional target for the supervised task.
-Other fields used during preprocessing and inference.
+`ptls` extracts only sequential features for unsupervised task and additional target for the supervised task.
+Other fields are used during preprocessing and inference.
 
 ## Feature names
 
-The main purpose of the feature naming convention is sequential and array features distinguish.
-They both are `np.ndarray` or `torch.tensor` and we can't use data type for distinguish.
+The main purpose of the feature naming convention is to distinguish between sequential and array features.
+They both are `np.ndarray` or `torch.tensor` so we can't use data type to distinguish.
 
-It's important to know feature type because:
+It's important to know the feature type because:
 
 - sequential align lengths with `pad_sequence`, arrays use `stack` during batch collection.
-- only sequential features used to get length of entire sequence
+- only sequential features can be used to get length of entire sequence
 - only sequential features are augmented by timeline modifications like slice, trx dropout or shuffle
 
 We introduce naming rules to solve type discrimination problems.
@@ -62,7 +62,7 @@ x = {
 
 `target` prefix are mandatory only for array features.
 
-Sometimes we need a time sequence. It used fo trx correct order, for time features and for some splits.
+Sometimes we need a time sequence. It used for trx correct order, for time features and for some splits.
 We expect that transaction timestamp stored in `event_time` field.
 
 ## Naming rules
@@ -95,7 +95,7 @@ print(dataset[0])
 
 ## Code usage
 
-Need to take into account the type of features and the use of naming rules is in the classes:
+Theese are the classes where it is necessary to take into account the type of features and the use of naming rules:
 
 - `ptls.data_load.feature_dict.FeatureDict`
 - `ptls.data_load.padded_batch.PaddedBatch`

--- a/docs/frames/coles.md
+++ b/docs/frames/coles.md
@@ -5,11 +5,11 @@ Original paper: [CoLES: Contrastive Learning for Event Sequences with Self-Super
 CoLES is a framework that learn neural network to compress sequential data into a single embedding.
 
 Imagine a credit card transaction history that can be an example of user behavioral.
-Each user have his own behavioral patterns which are projected to his transaction history.
-Repeatability of behavioral patterns lead to repeatability in transaction history.
+Each user has his own behavioral patterns which are projected to his transaction history.
+Repeatability of behavioral patterns leads to repeatability in transaction history.
 
 CoLES exploit repeatability of patterns to make embedding. It samples a few subsequences from original sequence
-and calculates an embeddings for each of them. Embeddings are assigned to his user.
+and calculates an embeddings for each of them. Embeddings are assigned to a corresponding user.
 Subsequences represent the same user and contain the same behavioral patterns. 
 CoLES catch these patterns by making closer users embeddings. It also tries to distance different users embeddings.
 
@@ -52,8 +52,8 @@ Notes:
 
 - there can be many types of class labels, this can be targets from supervised task.
 Labels for each class are provided by `ColesSupervisedDataset`.
-- class labels can be missed. Auxiliary loss are calculated only for labeled data.
-CoLES loss are calculated for all data.
+- class labels can be missed. Auxiliary loss is calculated only for labeled data.
+CoLES loss is calculated for all data.
 - auxiliary loss is `l_loss` attribute of `ColesSupervisedModule` constructor.
 
 
@@ -68,7 +68,7 @@ Use `ptls.frames.coles.ColesDataset` or `ptls.frames.coles.ColesIterableDataset`
 It's parametrised by `splitter` as `ColesDataset`.
 
 `ColesSupervisedDataset` requires a list of columns where target labels are stored (`cols_classes` attribute).
-It used to provide these labels to dataloader.
+It is used to provide these labels to dataloader.
 
 ## Coles losses and sampling strategies
 Use classes from:
@@ -80,9 +80,9 @@ Usage recommendations:
 
 - Auxiliary class labels don't change because they are client related. This means that you can use losses with memory
 to learn class centers in embedding space for `l_loss` in `ColesSupervisedModule`.
-Losses without memory calculates class center for batch.
+Losses without memory calculate class center for batch.
 - Don't use losses with memory as CoLES loss, cause Coles labels valid only in batch.
-CoLES labels is arange over batch, so e.g. 0-label correspond different clients in different batches.
+CoLES labels are aranged over batch, so e.g. 0-label correspond different clients in different batches.
 
 
 ## Head selection

--- a/docs/frames/common_usage.md
+++ b/docs/frames/common_usage.md
@@ -1,9 +1,9 @@
 # `ptls.frames` usage
 
-`frames` means frameworks. They are collects a popular technics to train a models.
+`frames` means frameworks. They are collections of popular model training technics.
 Each framework is a `LightningModule`. It means that you can train it with `pytorch_lightning.Trainer`.
 Frameworks consume data in a special format, so a `LightningDataModule` required.
-So there are three `pytorch_lightning` entities a required:
+So there are three `pytorch_lightning` entities required:
 
 - model
 - data
@@ -19,17 +19,17 @@ We make a special `torch.nn.Dataset` implementation for each framework. All of t
 - consume `map` or `iterable` input as dict of feature arrays
 - compatible with `ptls.frames.PtlsDataModule`
 
-Model is usually `seq_encoder` with `head` optional.
+Model is usually a `seq_encoder` with an optional `head`.
 We provide a model to framework assigned `LightningModule`.
 
 ## Example
 
-This example is for CoLES framework. You can try an others with the same way.
+This example is for CoLES framework. You can try others the same way.
 See module list in `ptls.frames` submodules. Check docstring for precise parameter tuning.
 
 ### Data generation
 
-We make a small test dataset. In real life you can use a many ways to load a data. See `ptls.data_load`.
+We make a small test dataset. In real life you can use many ways to load data. See `ptls.data_load`.
 
 ```python
 import torch
@@ -104,8 +104,8 @@ datamodule = PtlsDataModule(
 
 ### Model creation
 
-We have to create `seq_cncoder` that transform sequences to embedding 
-and create `CoLESModule` that will train `seq_cncoder`.
+We have to create `seq_cncoder` that transforms sequences to embedding 
+and create `CoLESModule` that will train `seq_encoder`.
 
 ```python
 import torch.optim
@@ -161,13 +161,13 @@ Now `coles_module` with `seq_encoder` are trained.
 
 This demo shows how to make embedding with pretrained `seq_encoder`.
 
-`pytorch_lightning.Trainer` have `predict` method that calls `seq_encoder.forward`.
+`pytorch_lightning.Trainer` has a `predict` method that calls `seq_encoder.forward`.
 `predict` requires `LightningModule` but `seq_encoder` is `torch.nn.Module`.
-We should cover `seq_encoder` to `LightningModule`.
+We should convert `seq_encoder` to `LightningModule`.
 
 We can use `CoLESModule` or any other module if available. In this example we can use `coles_module` object.
 Sometimes we have only `seq_encoder`, e.g. loaded from disk.
-`CoLESModule` have a little overhead. There are head, loss and metrics inside.
+`CoLESModule` has a little overhead. There are head, loss and metrics inside.
 
 Other way is using lightweight `ptls.frames.supervised.SequenceToTarget` module.
 It can run inference with only `seq_encoder`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ CoLES, SimCLR, CPC, VICReg, ...
     - Use one of the available `ptls.data_load.datasets` to define input for the models.
 2. **Choose framework for encoder train**.
     - There are both supervised of unsupervised frameworks in `ptls.frames`.
-    - Keep in mind that each framework requires his own batch format.
+    - Keep in mind that each framework requires its own batch format.
     Tools for batch collate can be found in the selected framework package.
 3. **Build encoder**.
     - All parts are available in `ptls.nn`.

--- a/docs/nn/seq_encoder.md
+++ b/docs/nn/seq_encoder.md
@@ -5,6 +5,7 @@ All classes from `ptls.nn.seq_encoder` also available in `ptls.nn`
 `ptls.nn.seq_encoder` takes into account sequential structure and the links between transactions.
 
 There are 2 types of seq encoders:
+
 - required embeddings as input
 - requires raw features as input
 
@@ -53,7 +54,7 @@ trx_encoder = TrxEncoder(
 seq_encoder = RnnEncoder(input_size=trx_encoder.output_size, hidden_size=16)
 
 z = trx_encoder(x)
-y = seq_encoder(z)  # embeddings wor each transaction
+y = seq_encoder(z)  # embeddings for each transaction
 seq_encoder.is_reduce_sequence = True
 h = seq_encoder(z)  # embeddings for sequences, aggregate all transactions in one embedding
 
@@ -61,7 +62,7 @@ assert y.payload.size() == (3, 8, 16)
 assert h.size() == (3, 16)
 ```
 
-Usually `seq_encoder` used with preliminary `trx_encoder`. It's possible to pack them to `torch.nn.Sequential`.
+Usually `seq_encoder` is used with preliminary `trx_encoder`. It's possible to pack them to `torch.nn.Sequential`.
 
 It's possible to add more layers between `trx_encoder` and `seq_encoder` (linear, normalisation, convolutions, ...). 
 They should work with PaddedBatch. Examples will be presented later. Such layers also works after `seq_encoder`
@@ -128,7 +129,7 @@ config = """
 model = hydra.utils.instantiate(OmegaConf.create(config))['model']
 ```
 
-The second config are simpler. Both of configs make an identical model. You can check:
+The second config is simpler. Both of configs make an identical model. You can check:
 ```python
 x = PaddedBatch(
     payload={
@@ -145,10 +146,10 @@ y = model(x)
 ## AggFeatureSeqEncoder
 
 `ptls.nn.AggFeatureSeqEncoder`.
-It looks like seq_encoder. It take raw features at input and provide reduced representation at output.
+It looks like seq_encoder. It takes raw features at input and provides reduced representation at output.
 This encoder creates features, which are good for boosting model. This is a strong baseline for many tasks.
-`AggFeatureSeqEncoder` eat the same input as other seq_encoders, and it can easily be replaced
-by rnn of transformer seq encoder.  It use gpu and works fast. It haven't parameters for learn.
+`AggFeatureSeqEncoder` takes the same input as other seq_encoders, and it can easily be replaced
+by rnn of transformer seq encoder.  It uses gpu and works fast. It doesn't have parameters for learn.
 
 Possible pipeline:
 ```python
@@ -157,7 +158,7 @@ agg_embeddings = trainer.predict(seq_encoder, dataloader)
 catboost_model.fit(agg_embeddings, target)
 ```
 
-We plain to split `AggFeatureSeqEncoder` into components which will be compatible with other ptls-layers.
+We plan to split `AggFeatureSeqEncoder` into components which will be compatible with other ptls-layers.
 It will be possible to choose flexible between `TrxEncoder` with `AggSeqEncoder` and `OheEncoder` with `RnnEncoder`.
 
 

--- a/docs/nn/trx_encoder.md
+++ b/docs/nn/trx_encoder.md
@@ -16,7 +16,7 @@ x = PaddedBatch(
     length=torch.Tensor([2, 8, 5]).long()
 )
 ```
-And se can define a TrxEncoder
+And we can define a TrxEncoder
 ```python
 model = TrxEncoder(
     embeddings={
@@ -30,7 +30,7 @@ We should provide feature description to `TrxEncoder`.
 Dictionary size and embedding size for categorical features. Scaler name for numerical features.
 `identity` means no rescaling.
 
-`TrxEncoder` concatenate all feature embeddings, sow output embedding size will be `6 + 2 + 1`.
+`TrxEncoder` concatenates all feature embeddings, sow output embedding size will be `6 + 2 + 1`.
 You may get output size from `TrxEncoder` with property:
 ```python
 >>> model.output_size

--- a/docs/ptls_preprocessing.md
+++ b/docs/ptls_preprocessing.md
@@ -15,7 +15,7 @@ Use `pandas` for a small dataset and `pyspark` for a large one.
 3. Prepare `event_time` column. Convert it to a timestamp for a date and time, or use any sortable format otherwise.
 4. Fit and transform categorical features, from categorical values to embedding indexes.
 5. Check numeric feature column types
-6. Split and groups dataframe by users. One row was one transaction, one row became a user with a list of transactions.
+6. Split and group dataframe by users. Before this operation a row represents a single transaction; after a row represents a user with and contains a list of all transactions by the user.
 7. Join user-level columns: target, labels, features.
 8. Done. Use data from memory or save it to parquet format.
 9. Save fitted preprocessing for future usage.

--- a/docs/sequential_data_definition.md
+++ b/docs/sequential_data_definition.md
@@ -33,12 +33,12 @@ We sort events by `date_time` for each user to assure correct event order.
 Each event (transaction) are described by categorical field `mcc_code`, numerical field `amount`, and time field `date_time`.
 These fields allow to distinguish events, vectorize them na use as a features.
 
-`pytorch-lifeatream` supports this format of data and provides the tools to process it throw the pipeline.
+`pytorch-lifeatream` supports this data format and provides the tools to process it through a pipeline.
 Data can be `pandas.DataFrame` or `pyspark.DataFrame`.
 
 ### Data collected in lists
 Table data should be converted to format more convenient for neural network feeding.
-There are steps:
+Here are the steps:
 
 1. Feature field transformation: encoding categorical features, amount normalizing, missing values imputing.
 This works like sklearn fit-transform preprocessors.
@@ -47,7 +47,7 @@ We transfer flat table with events to set of users with event collections.
 3. Split events by feature fields.
 Features are stored as 1d-arrays. Sequence orders are kept.
 
-Previous example with can be presented as (feature transformation missed for visibility):
+Previous example (сredit card transaction history) can be presented as (feature transformation missed for visibility):
 
 ```
 [
@@ -74,10 +74,10 @@ This is a main input data format in `pytorch-lifeatream`. Supported:
 - in-memory augmentations and transformations
 
 ## Dataset
-`pytorch-lifeatream` provide multiple `torch.Dataset` implementations.
-Dataset item present single user information and can be a combination of:
+`pytorch-lifeatream` provides multiple `torch.Dataset` implementations.
+Dataset item presents a single user information and can be a combination of:
 
-- `record` - is a dictionary where kees are feature names and values are 1d-tensors with feature sequences.
+- `record` - is a dictionary where keys are feature names and values are 1d-tensors with feature sequences.
 Similar as data collected in lists. 
 - `id` - how to identify a sequence
 - `target` - target value for supervised learning
@@ -91,11 +91,11 @@ X = dataset[0]
 ## DataLoader
 The main feature of `pytorch-lifestream` dataloader is customized `collate_fn`, provided to `torch.DataLoader` class.
 `collate_fn` collects single records of dictionaries to batch.
-Usually `collate_fn` pad and pack sequences into 2d tensors with shape `(B, T)`, where `B` - is sample num and `T` is max sequence length.
+Usually `collate_fn` pads and packs sequences into 2d tensors with shape `(B, T)`, where `B` - is sample num and `T` is max sequence length.
 Each feature packed separately.
 
-Output is `PaddedBatch` type which collect together packed sequences and lengths.
-`PaddedBatch` compatible with all `pytorch-lifestream` modules.
+Output is `PaddedBatch` type which collects together packed sequences and lengths.
+`PaddedBatch` is compatible with all `pytorch-lifestream` modules.
 
 Input and output example:
 ```python

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,17 +1,17 @@
 # Hyperparameters tuning
 
 We propose a demo for hyperparameters tuning with `hydra`, `optuna` and `tensorboard`.
-This is console application located in `demo/hparam_tuning`.
+This is a console application located in `demo/hparam_tuning`.
 
 # Intro
 
 After we build a network architecture we should tune hyperparameters.
-Automated tuning have a benefits:
+Automated tuning have benefits:
 
 - Automated iterations over hparam set is faster than manual choice
 - Automated iterations requires less operational costs
 - All results logged and can be inspected together
-- Iteration count limit allow measure quality improvement with fixed resources.
+- Iteration count limit allows measuring the quality improvement with fixed resources.
 - hparam optimisation tools implement effective strategy of parameter choice
 
 Keep in mind that is just a tool for hparam iteration.

--- a/ptls/make_datasets_spark.py
+++ b/ptls/make_datasets_spark.py
@@ -61,7 +61,13 @@ class DatasetConverter:
                                  '"#float", "#datetime", "#gender"')
 
         parser.add_argument('--dict', nargs='*', default=[])
-        parser.add_argument('--cols_category', nargs='*', default=[])
+        parser.add_argument('--cols_category', nargs='*', default=[],
+                            help = 'List of categorical columns. All categorical ' \
+                                'features are encoded with an encoder. ' \
+                                'Currently there\'s only one encoder that ' \
+                                'replaces categorical values with a corresponding frequency rank:' \
+                                'The most common value will be replaced with 1, ' \
+                                'second common value will be replaced by 2 etc.')
         parser.add_argument('--cols_log_norm', nargs='*', default=[],
                             help='List of columns to apply log transformation to. ' \
                                  'Log transformation is applied as signum(x) * log(|x| + 1)')

--- a/ptls/make_datasets_spark.py
+++ b/ptls/make_datasets_spark.py
@@ -63,11 +63,12 @@ class DatasetConverter:
         parser.add_argument('--dict', nargs='*', default=[])
         parser.add_argument('--cols_category', nargs='*', default=[],
                             help = 'List of categorical columns. All categorical ' \
-                                'features are encoded with an encoder. ' \
-                                'Currently there\'s only one encoder that ' \
-                                'replaces categorical values with a corresponding frequency rank:' \
-                                'The most common value will be replaced with 1, ' \
-                                'second common value will be replaced by 2 etc.')
+                                   'features are encoded with embedding indexes. ' \
+                                   'The indexes correspond to frequency rank:' \
+                                   'All values are sorted by frequency in descending order ' \
+                                   'and are numbered according to the order. ' \
+                                   'The most common value will be replaced with 1, ' \
+                                   'second common value will be replaced with 2 etc.')
         parser.add_argument('--cols_log_norm', nargs='*', default=[],
                             help='List of columns to apply log transformation to. ' \
                                  'Log transformation is applied as signum(x) * log(|x| + 1)')

--- a/ptls/make_datasets_spark.py
+++ b/ptls/make_datasets_spark.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 from random import Random
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -12,47 +13,87 @@ import pyspark.sql.functions as F
 import pyspark.sql.types as T
 from pyspark.sql import SparkSession
 from pyspark.sql import Window
+from pyspark.sql import DataFrame  # For typing
 
 
 logger = logging.getLogger(__name__)
 
 
 class DatasetConverter:
+    """
+    Converts datasets from transaction list to features for metric learning.
+
+    The class is designed to be run from command line with arguments.
+    Call python3 make_datasets_spark.py --help to see arguments description.
+    """
     def __init__(self):
         self.config = None
 
-    def parse_args(self, args=None):
+    def parse_args(self, args: Optional[List[str]]=None) -> None:
+        """
+        Parses command line arguments and saves them to self.config.
+
+        Arguments:
+        ----------
+        args: Optional[List[str]]
+            List of arguments to parse. If None, sys.argv is used.
+        """
         parser = argparse.ArgumentParser()
 
-        parser.add_argument('--data_path', type=os.path.abspath)
-        parser.add_argument('--trx_files', nargs='+')
-        parser.add_argument('--target_files', nargs='*', default=[])
+        parser.add_argument('--data_path', type=os.path.abspath, 
+                            help='Path to the directory containing trx files (datasets)')
+        parser.add_argument('--trx_files', nargs='+',
+                            help='List of dataset filenames with transaction features. ' \
+                                 'Note: target column will be ignored.' \
+                                 'Please use --target_files to specify targets.')
+        parser.add_argument('--target_files', nargs='*', default=[],
+                            help='List of target files containing client_id and target columns. '\
+                                'The files can overlap with trx_files or be separate.')
         parser.add_argument('--target_as_array', action='store_true')
 
         parser.add_argument('--print_dataset_info', action='store_true')
         parser.add_argument('--sample_fraction', type=float, default=None)
         parser.add_argument('--col_client_id', type=str)
-        parser.add_argument('--cols_event_time', nargs='+')
+        parser.add_argument('--cols_event_time', nargs='+', 
+                            help='Two arguments: 1) type of time transformation ' \
+                                 '2) time column name.\n' \
+                                 'Possible time transformation types: ' \
+                                 '"#float", "#datetime", "#gender"')
 
         parser.add_argument('--dict', nargs='*', default=[])
         parser.add_argument('--cols_category', nargs='*', default=[])
-        parser.add_argument('--cols_log_norm', nargs='*', default=[])
+        parser.add_argument('--cols_log_norm', nargs='*', default=[],
+                            help='List of columns to apply log transformation to. ' \
+                                 'Log transformation is applied as signum(x) * log(|x| + 1)')
         parser.add_argument('--col_target', nargs='*', default=[])
         parser.add_argument('--test_size', default='0.1')
-        parser.add_argument('--salt', type=int, default=42)
-        parser.add_argument('--max_trx_count', type=int, default=5000)
+        parser.add_argument('--salt', type=int, default=42,
+                            help='Random seed for client shuffling')
+        parser.add_argument('--max_trx_count', type=int, default=5000,
+                            help='All sequences (transactions) ' \
+                                 'exceeding this number will be removed')
 
         parser.add_argument('--output_train_path', type=os.path.abspath)
         parser.add_argument('--output_test_path', type=os.path.abspath)
         parser.add_argument('--output_test_ids_path', type=os.path.abspath)
         parser.add_argument('--save_partitioned_data', action='store_true')
-        parser.add_argument('--log_file', type=os.path.abspath)
+        parser.add_argument('--log_file', type=os.path.abspath, 
+                            help='File to dump logs to. If set logs will ' \
+                            'be present in stdout and in the file, otherwise only in stdout. ' \
+                            'Notice that stdout will always contain both ' \
+                            'Spark logs and script logs, which makes it hard to read. ' \
+                            'Thus, log_file is useful to be able to read only script logs.')
+
 
         args = parser.parse_args(args)
         logger.info('Parsed args:\n' + '\n'.join([f'  {k:15}: {v}' for k, v in vars(args).items()]))
         self.config = args
 
-    def spark_read_file(self, path):
+    def spark_read_file(self, path: str):
+        """
+        Creates a spark.DataFrame from a given file 
+        using the file extension to determine the format.
+        """
         spark = SparkSession.builder.getOrCreate()
 
         ext = os.path.splitext(path)[1]
@@ -66,10 +107,18 @@ class DatasetConverter:
     def path_to_file(self, file_name):
         return os.path.join(self.config.data_path, file_name)
 
-    def load_source_data(self, trx_files):
+    def load_source_data(self, trx_files: List[str]):
         """
-        :param trx_files:
-        :return: spark.DataFrame with `event_time` column of float type
+        Arguments:
+        ----------
+        trx_files: List[str]
+            List of filenames stored in `self.config.data_path` 
+            directory to load data from.
+
+        Returns:
+        --------
+        data: spark.DataFrame
+            spark.DataFrame with `event_time` column of float type
         """
         data = None
         for file in trx_files:
@@ -105,7 +154,7 @@ class DatasetConverter:
         df['% of total'] = df['cnt'] / df['cnt'].sum()
         return df
 
-    def get_encoder(self, df, col_name):
+    def get_encoder(self, df: DataFrame, col_name: str) -> DataFrame:
         df = df.withColumn(col_name, F.coalesce(F.col(col_name).cast('string'), F.lit('#EMPTY')))
 
         col_orig = '_orig_' + col_name
@@ -120,6 +169,8 @@ class DatasetConverter:
 
         df_encoder = df_encoder.repartition(1)
         df_encoder.persist()
+
+        # AFAIU this call is to trigger the computation since pyspark is lazy.
         _ = df_encoder.count()
 
         return df_encoder
@@ -221,8 +272,8 @@ class DatasetConverter:
         logger.info(f'Join with "{path}" done. New {col_counter} columns joined')
         return df
 
-    def trx_to_features(self, df_data, print_dataset_info,
-                        col_client_id, cols_event_time, cols_category, cols_log_norm, max_trx_count):
+    def trx_to_features(self, df_data, print_dataset_info: bool,
+                        col_client_id, cols_event_time, cols_category, cols_log_norm, max_trx_count: int):
         if print_dataset_info:
             unique_clients = df_data.select(col_client_id).distinct().count()
             logger.info(f'Found {unique_clients} unique clients')
@@ -443,6 +494,10 @@ class DatasetConverter:
         logging.basicConfig(level=logging.INFO, format='%(funcName)-20s   : %(message)s', handlers=handlers)
 
     def load_transactions(self):
+        """
+        Returns a single spark.DataFrame with transaction 
+        data collected from all trx_files.
+        """
         spark = SparkSession.builder.getOrCreate()
 
         source_data = self.load_source_data(trx_files=self.config.trx_files)

--- a/ptls/preprocessing/pandas_preprocessor.py
+++ b/ptls/preprocessing/pandas_preprocessor.py
@@ -41,7 +41,7 @@ class PandasDataPreprocessor(DataPreprocessor):
         - 'none': without transformation, `col_event_time` is in correct format. Used `ColIdentityEncoder`
             Original column is kept by default cause it can be any type and we may use it in the future
     cols_category : list[str]
-        list of category columns. Each can me column name or `ColCategoryTransformer` implementation.
+        list of category columns. Each can be column name or `ColCategoryTransformer` implementation.
     category_transformation: str
         name of transformation for column names from `cols_category`
         - 'frequency': frequency encoding with `FrequencyEncoder`

--- a/ptls/preprocessing/pandas_preprocessor.py
+++ b/ptls/preprocessing/pandas_preprocessor.py
@@ -19,7 +19,7 @@ class PandasDataPreprocessor(DataPreprocessor):
     """Data preprocessor based on pandas.DataFrame
 
     During preprocessing it
-        * transform datetime column to `event_time`
+        * transforms datetime column to `event_time`
         * encodes category columns into indexes;
         * groups flat data by `col_id`;
         * arranges data into list of dicts with features

--- a/ptls/preprocessing/pyspark_preprocessor.py
+++ b/ptls/preprocessing/pyspark_preprocessor.py
@@ -26,7 +26,7 @@ class PysparkDataPreprocessor(DataPreprocessor):
     """Data preprocessor based on pyspark.sql.DataFrame
 
     During preprocessing it
-        * transform `cols_event_time` column with date and time
+        * transforms `cols_event_time` column with date and time
         * encodes category columns `cols_category` into ints;
         * apply logarithm transformation to `cols_log_norm' columns;
         * (Optional) select the last `max_trx_count` transactions for each `col_id`;


### PR DESCRIPTION
1. Fixed typos and grammatical errors in documentation
2. Added docstrings and help properties of cmd line args in make_datasets_spark.py 