### PR TITLE
changing multimodal module for time sorting on gpu

### DIFF
--- a/ptls/frames/coles/multimodal_dataset.py
+++ b/ptls/frames/coles/multimodal_dataset.py
@@ -4,7 +4,6 @@ from functools import reduce
 from collections import defaultdict
 from ptls.data_load.feature_dict import FeatureDict
 from ptls.data_load.padded_batch import PaddedBatch
-from ptls.frames.coles import MultiModalSortTimeSeqEncoderContainer
 
 def collate_feature_dict(batch):
     new_x_ = defaultdict(list)
@@ -78,8 +77,7 @@ class MultiModalDataset(FeatureDict, torch.utils.data.Dataset):
         col_id:
             column name with user_id
         source_names:
-            column name with name sources, must be specified in the same order as trx_encoders in 
-            ptls.frames.coles.multimodal_module.MultiModalSortTimeSeqEncoderContainer
+            column name with name sources
         col_time:
             column name with event_time
         """
@@ -107,97 +105,51 @@ class MultiModalDataset(FeatureDict, torch.utils.data.Dataset):
             
     def split_source(self, feature_arrays):
         res = defaultdict(dict)
-        
         for feature_name, feature_array in feature_arrays.items():
             if feature_name == self.col_id:
                 res[self.col_id] = feature_array
             else:
                 source_name, feature_name_transform = self.get_names(feature_name)
                 res[source_name][feature_name_transform] = feature_array
-        
         for source in self.source_names:
             if source not in res:
                 res[source] = {source_feature: torch.tensor([]) for source_feature in self.source_features[source]}
-        
         return res
     
     def get_names(self, feature_name):
         idx_del = feature_name.find('_')
         return feature_name[:idx_del], feature_name[idx_del + 1:]
                 
+    
     def get_splits(self, feature_arrays):
         res = {}
         common_local_time = []
-
         for source_name, feature_dict in feature_arrays.items():
             if source_name != self.col_id:
                 local_date = feature_dict[self.col_time]
                 common_local_time.extend([(int(loc), ind, source_name) for ind, loc in enumerate(local_date)])
-
         common_local_time.sort(key=lambda x: x[0])
-
-        local_times_tensor = torch.tensor([x[0] for x in common_local_time])
-        indexes = self.splitter.split(local_times_tensor)
-
+       
+        indexes = self.splitter.split(torch.tensor([x[0] for x in common_local_time]))
         res_ind = []
         for inds in indexes:
             dct = defaultdict(list)
             for ind in inds:
-                _, loc_index, src_name = common_local_time[ind]
-                dct[src_name].append(loc_index)
-            res_ind.append(dct)
-
-        for src_name, feature_dict in feature_arrays.items():
-            if src_name != self.col_id:
-                filtered_features = {k: v for k, v in feature_dict.items() if self.is_seq_feature(k, v)}
-                res[src_name] = [{k: v[ix[src_name]] for k, v in filtered_features.items()} for ix in res_ind]
-
+                dct[common_local_time[ind][2]].append(common_local_time[ind][1])
+            res_ind.append(dct)  
+                
+        for source_name, feature_dict in feature_arrays.items():
+            if source_name != self.col_id:
+                res[source_name] = [{k: v[ix[source_name]] for k, v in feature_dict.items() if self.is_seq_feature(k, v)} for ix in res_ind]
         return res
-
+        
     def collate_fn(self, batch, return_dct_labels=False):
         dict_class_labels = get_dict_class_labels(batch)
         batch = reduce(lambda x, y: {k: x[k] + y[k] for k in x if k in y}, batch)
-        
         padded_batch = collate_multimodal_feature_dict(batch)
-        source_indices = {source: index for index, source in enumerate(self.source_names)}
-        
-        # common_local_time is a tensor containing information about event indexes from each modality for each sample
-        # dim_0 - the number of samples in the batch
-        # dim_1 - total length of the sample (including all modalities)
-        # dim_2 = 3 - event_time, index, source
-        dim_0 = padded_batch[self.source_names[0]].payload[self.col_time].shape[0]
-        dim_1 = sum(subseq.payload[self.col_time].shape[1] for source_name, subseq in padded_batch.items())
-        common_local_time_shape = (dim_0, dim_1, 3)
-
-        common_local_time = torch.zeros(common_local_time_shape, dtype=torch.double)
-
-        current_dim_1 = 0
-        for source_name, subseq in padded_batch.items():
-            source_index = source_indices[source_name]
-            
-            # current_dim_1_end - a pointer to the index from which to fill in the next modality
-            current_dim_1_end = current_dim_1 + subseq.payload[self.col_time].shape[1]
-            
-            # each modality within itself is already sorted by time 
-            # so you can take arange as indexes inside the modality
-            common_local_time[:, current_dim_1:current_dim_1_end, 1] = torch.arange(subseq.payload[self.col_time].shape[1])
-            common_local_time[:, current_dim_1:current_dim_1_end, 2] = source_index
-            
-            # subseq_local_times - event_time for each modality, padding is replaced by inf
-            subseq_local_times = subseq.payload[self.col_time].type(torch.FloatTensor)
-            subseq_local_times_masked = subseq_local_times.masked_fill_(subseq_local_times == 0, float('inf'))
-            common_local_time[:, current_dim_1:current_dim_1_end, 0] = subseq_local_times_masked
-            current_dim_1 = current_dim_1_end
-        
-        # getting indexes sorted by event_time order
-        indices = common_local_time[:,:,0].sort(dim=1, stable=True)[1]
-        
-        # gathering of the final tensor containing the order of the indies within each modality
-        # and a pointer to the modality to which the index belongs
-        common_local_time_sorted = torch.gather(common_local_time, 1, indices.unsqueeze(-1).expand(-1, -1, 3))[:, :, 1:]      
         if return_dct_labels:
-            return (padded_batch, common_local_time_sorted.short()), dict_class_labels
-        return (padded_batch, common_local_time_sorted.short()), dict_class_labels[list(dict_class_labels.keys())[0]]
+            return padded_batch, dict_class_labels
+        return padded_batch, dict_class_labels[list(dict_class_labels.keys())[0]]
 
     
 class MultiModalIterableDataset(MultiModalDataset, torch.utils.data.IterableDataset):

--- a/ptls/frames/coles/multimodal_dataset.py
+++ b/ptls/frames/coles/multimodal_dataset.py
@@ -77,7 +77,8 @@ class MultiModalDataset(FeatureDict, torch.utils.data.Dataset):
         col_id:
             column name with user_id
         source_names:
-            column name with name sources
+            column name with name sources, must be specified in the same order as trx_encoders in 
+            ptls.frames.coles.multimodal_module.MultiModalSortTimeSeqEncoderContainer
         col_time:
             column name with event_time
         """

--- a/ptls/frames/coles/multimodal_inference_dataset.py
+++ b/ptls/frames/coles/multimodal_inference_dataset.py
@@ -56,7 +56,7 @@ class MultiModalInferenceDataset(FeatureDict, torch.utils.data.Dataset):
     def get_names(self, feature_name):
         idx_del = feature_name.find('_')
         return feature_name[:idx_del], feature_name[idx_del + 1:]
-
+    
     @staticmethod
     def collate_fn(batch, return_dct_labels=False, col_id = 'client_id'):
         batch_ids = []
@@ -69,8 +69,8 @@ class MultiModalInferenceDataset(FeatureDict, torch.utils.data.Dataset):
         padded_batch = collate_multimodal_feature_dict(batch)
         if return_dct_labels:
             return padded_batch, dict_class_labels
-        return (padded_batch, None), batch_ids
-    
+        return padded_batch, batch_ids
+
     
 class MultiModalInferenceIterableDataset(MultiModalInferenceDataset, torch.utils.data.IterableDataset):
     pass

--- a/ptls/frames/coles/multimodal_module.py
+++ b/ptls/frames/coles/multimodal_module.py
@@ -27,7 +27,7 @@ class MultiModalSortTimeSeqEncoderContainer(torch.nn.Module):
     An example of use can be found at the link:
     https://github.com/dllllb/pytorch-lifestream/blob/main/ptls_tests/test_frames/test_coles/test_multimodal_coles_module.py
     """
-    
+
     def __init__(self,
                  trx_encoders,
                  seq_encoder_cls, 
@@ -44,8 +44,9 @@ class MultiModalSortTimeSeqEncoderContainer(torch.nn.Module):
             is_reduce_sequence=is_reduce_sequence,
             **seq_encoder_params,
         )
-        self.is_inference = False
+        
         self.col_time = col_time
+        self.input_size = input_size
     
     @property
     def is_reduce_sequence(self):
@@ -58,11 +59,7 @@ class MultiModalSortTimeSeqEncoderContainer(torch.nn.Module):
     @property
     def embedding_size(self):
         return self.seq_encoder.embedding_size
-
-    def get_tensor_by_indices(self, tensor, indices):
-        batch_size = tensor.shape[0]
-        return tensor[:, indices, :][torch.arange(batch_size), torch.arange(batch_size), :, :]
-    
+        
     def merge_by_time(self, x):
         device = list(x.values())[1][0].device
         batch, batch_time = torch.tensor([], device=device), torch.tensor([], device=device)
@@ -73,40 +70,22 @@ class MultiModalSortTimeSeqEncoderContainer(torch.nn.Module):
         
         batch_time[batch_time == 0] = float('inf')
         indices_time = torch.argsort(batch_time, dim=1)
-        batch = self.get_tensor_by_indices(batch, indices_time)
+        indices_time = indices_time.unsqueeze(-1).expand(-1, -1, self.input_size)
+        batch = torch.gather(batch, 1, indices_time)
         return batch
-    
-    def merge_by_time_by_index(self, x, indices):
-        m, n, _ = indices.size()
-        sources = list(x.keys())
-        emb_size = x[sources[0]][1].payload.shape[2]
-        output_embeddings = torch.zeros(m, n, emb_size, device=indices.device)
-
-        mod_indices = indices[:, :, 1].long()
-        emb_indices = indices[:, :, 0].long()
-
-        for mod in range(len(sources)):
-            mod_mask = mod_indices == mod
-            embeddings = x[sources[mod]][1].payload
-
-            gather_indices =mod_mask.unsqueeze(-1).expand(-1, -1, embeddings.size(2)) * emb_indices.unsqueeze(-1)
-            selected_embeddings = torch.gather(embeddings, 1, gather_indices)
-            output_embeddings = torch.where(mod_mask.unsqueeze(-1), selected_embeddings, output_embeddings)
-
-        return output_embeddings
             
     def trx_encoder_wrapper(self, x_source, trx_encoder, col_time):
         if torch.nonzero(x_source.seq_lens).size()[0] == 0:
             return x_source.seq_lens, 'None', 'None'
         return x_source.seq_lens, x_source.payload[col_time], trx_encoder(x_source)
-        
+    
     def multimodal_trx_encoder(self, x):
         res = {}
         tmp_el = list(x.values())[0]
         
         batch_size = tmp_el.payload[self.col_time].shape[0]
         length = torch.zeros(batch_size, device=tmp_el.device).int()
-
+        
         for source, trx_encoder in self.trx_encoders.items():
             enc_res = self.trx_encoder_wrapper(x[source], trx_encoder, self.col_time)
             source_length, res[source] = enc_res[0], (enc_res[1], enc_res[2])
@@ -114,12 +93,8 @@ class MultiModalSortTimeSeqEncoderContainer(torch.nn.Module):
         return res, length
             
     def forward(self, x):
-        x, time_index = x
         x, length = self.multimodal_trx_encoder(x)
-        if self.is_inference:
-            x = self.merge_by_time(x)
-        else:
-            x = self.merge_by_time_by_index(x, time_index)
+        x = self.merge_by_time(x)
         padded_x = PaddedBatch(payload=x, length=length)
         x = self.seq_encoder(padded_x)
         return x

--- a/ptls/frames/coles/multimodal_supervised_dataset.py
+++ b/ptls/frames/coles/multimodal_supervised_dataset.py
@@ -4,7 +4,7 @@ from functools import reduce
 from collections import defaultdict
 from ptls.data_load.feature_dict import FeatureDict
 from ptls.frames.coles.multimodal_dataset import collate_feature_dict, collate_multimodal_feature_dict, get_dict_class_labels
-            
+
 
 class MultiModalSupervisedDataset(FeatureDict, torch.utils.data.Dataset):
     def __init__(
@@ -14,7 +14,7 @@ class MultiModalSupervisedDataset(FeatureDict, torch.utils.data.Dataset):
         source_names,
         col_id='client_id',
         col_time='event_time',
-        
+
         target_name = None,
         target_dtype = None,
         *args, **kwargs
@@ -39,28 +39,28 @@ class MultiModalSupervisedDataset(FeatureDict, torch.utils.data.Dataset):
             int or float
         """
         super().__init__(*args, **kwargs)
-        
+
         self.data = data
         self.col_time = col_time
         self.col_id = col_id
         self.source_names = source_names
         self.source_features = source_features
-        
+
         self.target_name = target_name
         self.target_dtype = target_dtype
-        
+
     def __len__(self):
         return len(self.data)
-    
+
     def __getitem__(self, idx):
         feature_arrays = self.data[idx]
         return self.split_source(feature_arrays)
-    
+
     def __iter__(self):
         for feature_arrays in self.data:
             split_data = self.split_source(feature_arrays)
             yield split_data
-            
+
     def split_source(self, feature_arrays):
         res = defaultdict(dict)
         for feature_name, feature_array in feature_arrays.items():
@@ -79,12 +79,12 @@ class MultiModalSupervisedDataset(FeatureDict, torch.utils.data.Dataset):
         for source in res:
             res1[source] = [res[source]]
         return res1
-    
+
     def get_names(self, feature_name):
         idx_del = feature_name.find('_')
         return feature_name[:idx_del], feature_name[idx_del + 1:]
-            
-    
+
+
     def collate_fn(self, batch, return_dct_labels=False):
         dict_class_labels = get_dict_class_labels(batch)
         batch_y = []
@@ -93,32 +93,8 @@ class MultiModalSupervisedDataset(FeatureDict, torch.utils.data.Dataset):
             del sample[self.target_name]
         batch = reduce(lambda x, y: {k: x[k] + y[k] for k in x if k in y}, batch)
         padded_batch = collate_multimodal_feature_dict(batch)
-        source_indices = {source: index for index, source in enumerate(self.source_names)}
-        
-        dim_0 = padded_batch[self.source_names[0]].payload[self.col_time].shape[0]
-        dim_1 = sum(subseq.payload[self.col_time].shape[1] for source_name, subseq in padded_batch.items())
-        common_local_time_shape = (dim_0, dim_1, 3)
+        return padded_batch, torch.Tensor(batch_y)
 
-        common_local_time = torch.zeros(common_local_time_shape, dtype=torch.double)
-        current_dim_1 = 0
-        for source_name, subseq in padded_batch.items():
-            source_index = source_indices[source_name]
-           
-            current_dim_1_end = current_dim_1 + subseq.payload[self.col_time].shape[1]
-            common_local_time[:, current_dim_1:current_dim_1_end, 1] = torch.arange(subseq.payload[self.col_time].shape[1])
-            common_local_time[:, current_dim_1:current_dim_1_end, 2] = source_index
-                
-            subseq_local_times = subseq.payload[self.col_time].type(torch.FloatTensor)
-            subseq_local_times_masked = subseq_local_times.masked_fill_(subseq_local_times == 0, float('inf'))
-            common_local_time[:, current_dim_1:current_dim_1_end, 0] = subseq_local_times_masked
-            current_dim_1 = current_dim_1_end
-        indices = common_local_time[:,:,0].sort(dim=1, stable=True)[1]
 
-        common_local_time_sorted = torch.gather(common_local_time, 1, indices.unsqueeze(-1).expand(-1, -1, 3))[:, :, 1:]      
-    
-        
-        return (padded_batch, common_local_time_sorted.short()), torch.Tensor(batch_y)
-
-    
 class MultiModalSupervisedIterableDataset(MultiModalSupervisedDataset, torch.utils.data.IterableDataset):
     pass

--- a/ptls/pl_inference_multimodal.py
+++ b/ptls/pl_inference_multimodal.py
@@ -56,7 +56,6 @@ def main(conf: DictConfig):
         col_id = conf.collate_fn.col_id
     )
     model.model.is_reduce_sequence = True
-    model.model.is_inference = True
     dataset_inference = hydra.utils.instantiate(conf.inference.dataset)
     collate_fn = hydra.utils.instantiate(conf.collate_fn)
     inference_dl = DataLoader(


### PR DESCRIPTION
I found out that the drop in memory on the gpu in the multimodal module was caused by the get_tensor_by_indices function. 
I returned the time sorting to the gpu, got rid of the get_tensor_by_indices function by replacing it with torch.gather. Made the appropriate changes to the multimodal dataset. 
The changes increase the speed of train (got rid of the bottleneck in the dataloader), huge batches are also placed in gpu memory.