### PR TITLE
Fix tabformer_mask method

### DIFF
--- a/ptls/frames/tabformer/tabformer_module.py
+++ b/ptls/frames/tabformer/tabformer_module.py
@@ -154,7 +154,7 @@ class TabformerPretrainModule(pl.LightningModule):
             # The rest of the time (10% of the time) we keep the masked input tokens unchanged
             indices_random = (torch.bernoulli(torch.full(labels.shape, 0.5)).bool().to(inputs.device) & masked_indices & ~indices_replaced)
     
-            return labels.permute(1, 2, 0), masked_indices.permute(1, 2, 0), indices_replaced.permute(1, 2, 0)
+            return labels.permute(1, 2, 0), masked_indices.permute(1, 2, 0), indices_random.permute(1, 2, 0)
 
     def loss_tabformer(self, x: PaddedBatch, target, is_train_step):
         out = self.forward(x)


### PR DESCRIPTION
Здравствуйте! Исправил опечатку в возвращаемых методом tabformer_mask значениях - indices_random создавался в методе, но на его месте передавался indices_replaced, хотя в training_step видно, что должны быть именно indices_random. После исправления обучаться стало чуть лучше.